### PR TITLE
Switch from volta to mise and add emeraldbanks account

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -70,3 +70,5 @@ alias gtok="gcloud auth print-access-token |tr -d '\n' | pbcopy"
 
 # generate lowercase uuid
 alias uuidgen='uuidgen | tr "[:upper:]" "[:lower:]"'
+
+claude='claude --allow-dangerously-skip-permissions'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "opus",
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
@@ -46,5 +47,5 @@
       "There is more to this than meets the eye"
     ]
   },
-  "model": "opus"
+  "skipDangerousModePermissionPrompt": true
 }

--- a/.config/gh/hosts.yml
+++ b/.config/gh/hosts.yml
@@ -1,5 +1,6 @@
 github.com:
-    git_protocol: ssh
+    git_protocol: https
     users:
         brandonmbanks:
-    user: brandonmbanks
+        emeraldbanks:
+    user: emeraldbanks

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,4 @@
+[tools]
+aube = "latest"
+node = "lts"
+pnpm = "latest"

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -18,7 +18,6 @@ zsh_add_file "scripts.zsh"
 # plugins
 [ -f "$HOME/.local/share/zap/zap.zsh" ] && source "$HOME/.local/share/zap/zap.zsh"
 plug "zsh-users/zsh-autosuggestions"
-plug "zsh-users/zsh-syntax-highlighting"
 plug "hlissner/zsh-autopair"
 
 # rust
@@ -48,3 +47,7 @@ zsh_add_file "plugins/cursor.zsh"
 eval "$(starship init zsh)"
 
 eval "$(zoxide init --cmd cd zsh)"
+
+# must be sourced last so it can wrap all ZLE (Zsh Line Editor) widgets
+plug "zsh-users/zsh-syntax-highlighting"
+eval "$(/Users/banks/.local/bin/mise activate zsh)"

--- a/.gitconfig
+++ b/.gitconfig
@@ -30,3 +30,5 @@
 	defaultBranch = main
 [rerere]
 	enabled = true
+[includeIf "hasconfig:remote.*.url:git@github.com:emeraldbanks/**"]
+  path = ~/.gitconfig.emeraldbanks

--- a/.zshenv
+++ b/.zshenv
@@ -16,9 +16,6 @@ export VIMCONFIG="$XDG_CONFIG_HOME/nvim"
 export GOPATH=$HOME/go
 export GOBIN=$GOPATH/bin
 
-# volta
-export VOLTA_HOME="$HOME/.volta"
-
 export COMPOSE_BAKE=true
 
 # path
@@ -28,4 +25,3 @@ export PATH=/usr/local/bin:$PATH
 export PATH=/usr/local/go/bin:$PATH
 export PATH=$HOME/.temporalio/bin/:$PATH
 export PATH="$(brew --prefix libpq)/bin:$PATH"
-export PATH="$VOLTA_HOME/bin:$PATH"


### PR DESCRIPTION
- Replace volta with mise for runtime version management (.zshenv, .zshrc, .config/mise/config.toml).
- Add emeraldbanks GitHub account: gh switches to https, gitconfig includes ~/.gitconfig.emeraldbanks for matching remotes.
- Reorder zsh-syntax-highlighting to load last so it can wrap all ZLE widgets.
- Claude Code: set skipDangerousModePermissionPrompt and add a --allow-dangerously-skip-permissions alias.