### PR TITLE
Make mise global config machine-local

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,4 +1,0 @@
-[tools]
-aube = "latest"
-node = "lts"
-pnpm = "latest"

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ wezterm-icon/
 # local-only
 .claude/settings.local.json
 
+# machine-local mise tool versions (differ per machine)
+.config/mise/config.toml
+
 # credentials
 .config/stripe/

--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -5,3 +5,4 @@
 ^\.gitignore$
 ^\.stow-local-ignore$
 ^\.claude/settings\.local\.json$
+^\.config/mise/config\.toml$


### PR DESCRIPTION
mise global tool versions are inherently machine-specific (this machine keeps node/pnpm on volta with only go on mise; the other machine uses mise for node/pnpm). So the shared repo shouldn't force one config onto every machine.

## Changes
- `git rm .config/mise/config.toml` — untrack it
- add `.config/mise/config.toml` to `.gitignore` and `.stow-local-ignore`

Each machine now manages its own `~/.config/mise/config.toml`, and `stow .` no longer conflicts with the existing global config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)